### PR TITLE
Updated case on plugin file name

### DIFF
--- a/plugins/FakePlugin.py
+++ b/plugins/FakePlugin.py
@@ -6,7 +6,7 @@ from PluginSystem import PluginBase
 """
 Plugin used for testing.
 
-The class name must be the same as the file name.
+The class name must be the same as the file name. (Case Sensitive)
 """
 class FakePlugin(PluginBase.PluginBase):
 


### PR DESCRIPTION
This PR is to solve an issue I found with the way git changing directory names. When I originally named the fakePlugin, I used lower camel case. When I updated it in my local, I fixed it to PascalCase, however, git did not commit the PascalCase change. Git used the previous camelCase. I referenced [this stackoverflow](https://stackoverflow.com/questions/6899582/i-change-the-capitalization-of-a-directory-and-git-doesnt-seem-to-pick-up-on-it) article to fix the issue.